### PR TITLE
fix issue with conflicting action statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - BUGFIX
-  - fix issue if `tags` is not defined for a task object
+  - fix metadata handling to prevent parsing issues
+    on Ansible upstream functions (#35)


### PR DESCRIPTION
This PR will address https://github.com/xoxys/ansible-later/issues/35.

Collected metadata will be temp. removed from the raw task dict before
passing it to Ansibles `ModuleArgsParser` class. After processing, the
metadata will be added back to the result dict.